### PR TITLE
Fix payment recording UUID type error and improve error handling

### DIFF
--- a/src/components/payments/RecordPaymentDialog.tsx
+++ b/src/components/payments/RecordPaymentDialog.tsx
@@ -123,10 +123,11 @@ const onSubmit = async (data: PaymentFormData) => {
       setDialogOpen(false);
       onPaymentRecorded();
     } catch (error) {
-      console.error("Error recording payment:", error);
+      const msg = getErrorMessage(error);
+      console.error("Error recording payment:", msg, error);
       toast({
         title: "Error",
-        description: getErrorMessage(error),
+        description: msg,
         variant: "destructive",
       });
     }


### PR DESCRIPTION
## Purpose

Fix a runtime error where payment recording failed due to a UUID type mismatch ("related_id" is of type uuid but expression is of type text). Users were unable to record payments through the system, with test payments not being recorded properly. The goal was to audit the error, test manual payment insertion, and resolve the underlying issue.

## Code changes

- **Enhanced error handling**: Improved `getErrorMessage` function in `RecordPaymentDialog.tsx` to better handle Supabase/PostgreSQL errors, including specific handling for error codes and hints
- **RLS-safe payment insertion**: Modified payment insertion to use a safer approach that doesn't require returning rows, addressing potential RLS (Row Level Security) restrictions
- **Fallback allocation logic**: Updated payment allocation to fetch the last payment ID when direct return is blocked, with graceful error handling
- **New test payment component**: Added `TestPaymentButton.tsx` component for manual testing of payment insertion with proper tenant lookup and error handling
- **Console log filtering**: Extended console log cleaner to suppress ResizeObserver noise in production
- **UI integration**: Added the test payment button to the Payments page for easier debugging and testing

The changes ensure payment recording works reliably even with strict database security policies while providing better error messages for debugging.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fb6b93654de3451081824de51c65e99b/spark-world)

👀 [Preview Link](https://fb6b93654de3451081824de51c65e99b-spark-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fb6b93654de3451081824de51c65e99b</projectId>-->
<!--<branchName>spark-world</branchName>-->